### PR TITLE
feat: rename plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# plugin-payments-example
+# api-plugin-payments-example
 
-[![npm (scoped)](https://img.shields.io/npm/v/@reactioncommerce/plugin-payments-example.svg)](https://www.npmjs.com/package/@reactioncommerce/plugin-payments-example)
-[![CircleCI](https://circleci.com/gh/reactioncommerce/plugin-payments-example.svg?style=svg)](https://circleci.com/gh/reactioncommerce/plugin-payments-example)
+[![npm (scoped)](https://img.shields.io/npm/v/@reactioncommerce/api-plugin-payments-example.svg)](https://www.npmjs.com/package/@reactioncommerce/api-plugin-payments-example)
+[![CircleCI](https://circleci.com/gh/reactioncommerce/api-plugin-payments-example.svg?style=svg)](https://circleci.com/gh/reactioncommerce/api-plugin-payments-example)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 ## Summary

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@reactioncommerce/plugin-navigation",
+  "name": "@reactioncommerce/api-plugin-payments-example",
   "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
@@ -2981,7 +2981,8 @@
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
     },
     "co": {
       "version": "4.6.0",
@@ -6483,6 +6484,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
       "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
+      "dev": true,
       "requires": {
         "lodash._baseisequal": "^3.0.0",
         "lodash._bindcallback": "^3.0.0",
@@ -6494,6 +6496,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
       "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
+      "dev": true,
       "requires": {
         "lodash.keys": "^3.0.0"
       }
@@ -6501,17 +6504,20 @@
     "lodash._basefind": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basefind/-/lodash._basefind-3.0.0.tgz",
-      "integrity": "sha1-srugXMZF+XLeLPkl+iv2Og9gyK4="
+      "integrity": "sha1-srugXMZF+XLeLPkl+iv2Og9gyK4=",
+      "dev": true
     },
     "lodash._basefindindex": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/lodash._basefindindex/-/lodash._basefindindex-3.6.0.tgz",
-      "integrity": "sha1-8IM2ChsCJBjtgbyJm+sxLiHnSk8="
+      "integrity": "sha1-8IM2ChsCJBjtgbyJm+sxLiHnSk8=",
+      "dev": true
     },
     "lodash._baseisequal": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
       "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
+      "dev": true,
       "requires": {
         "lodash.isarray": "^3.0.0",
         "lodash.istypedarray": "^3.0.0",
@@ -6522,6 +6528,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lodash._baseismatch/-/lodash._baseismatch-3.1.3.tgz",
       "integrity": "sha1-Byj8SO+hFpnT1fLXMEnyqxPED9U=",
+      "dev": true,
       "requires": {
         "lodash._baseisequal": "^3.0.0"
       }
@@ -6530,6 +6537,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._basematches/-/lodash._basematches-3.2.0.tgz",
       "integrity": "sha1-9H4D8H7CB4SrCWjQy2y1l+IQEVg=",
+      "dev": true,
       "requires": {
         "lodash._baseismatch": "^3.0.0",
         "lodash.pairs": "^3.0.0"
@@ -6538,12 +6546,14 @@
     "lodash._bindcallback": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
     },
     "lodash.capitalize": {
       "version": "4.2.1",
@@ -6560,17 +6570,20 @@
     "lodash.every": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.every/-/lodash.every-4.6.0.tgz",
-      "integrity": "sha1-64mYS+vENkJ5uzrvu9HKGb+mxqc="
+      "integrity": "sha1-64mYS+vENkJ5uzrvu9HKGb+mxqc=",
+      "dev": true
     },
     "lodash.find": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
+      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
+      "dev": true
     },
     "lodash.findwhere": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.findwhere/-/lodash.findwhere-3.1.0.tgz",
       "integrity": "sha1-eTfTTz6sgY3sf6lOjKXib9uhz8E=",
+      "dev": true,
       "requires": {
         "lodash._basematches": "^3.0.0",
         "lodash.find": "^3.0.0"
@@ -6580,6 +6593,7 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-3.2.1.tgz",
           "integrity": "sha1-BG4xnzrOkSrGySRsf2g8XsB7Nq0=",
+          "dev": true,
           "requires": {
             "lodash._basecallback": "^3.0.0",
             "lodash._baseeach": "^3.0.0",
@@ -6594,7 +6608,8 @@
     "lodash.foreach": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
+      "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -6605,22 +6620,26 @@
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+      "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
     },
     "lodash.isempty": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
+      "dev": true
     },
     "lodash.ismatch": {
       "version": "4.4.0",
@@ -6631,7 +6650,8 @@
     "lodash.isobject": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
+      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
+      "dev": true
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
@@ -6648,12 +6668,14 @@
     "lodash.istypedarray": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
-      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
+      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
+      "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
       "requires": {
         "lodash._getnative": "^3.0.0",
         "lodash.isarguments": "^3.0.0",
@@ -6663,12 +6685,14 @@
     "lodash.omit": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
+      "dev": true
     },
     "lodash.pairs": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
       "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
+      "dev": true,
       "requires": {
         "lodash.keys": "^3.0.0"
       }
@@ -6676,7 +6700,8 @@
     "lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
     },
     "lodash.set": {
       "version": "4.3.2",
@@ -6699,12 +6724,14 @@
     "lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
+      "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
     },
     "lodash.uniqby": {
       "version": "4.7.0",
@@ -6715,7 +6742,8 @@
     "lodash.without": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
+      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
+      "dev": true
     },
     "lolex": {
       "version": "5.1.2",
@@ -7011,6 +7039,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/message-box/-/message-box-0.2.2.tgz",
       "integrity": "sha512-A32m9D2ZaE08ZaXoE74AjcKwjtwwEhDT2EeY7A3YMAEB4ypL0uMZw7HegwZ806GIWyY4VLwe3kGO9reIdjwiRg==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.14"
       }
@@ -7117,6 +7146,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/mongo-object/-/mongo-object-0.1.3.tgz",
       "integrity": "sha512-m3vs+a1JkvRXELJMe2ieMmBe03NUy6bctGjWicRhReYj8brDi0ojKHLKLmXWr/RupNaFP8Q7/x8xG8GpFtp9wg==",
+      "dev": true,
       "requires": {
         "lodash.foreach": "^4.5.0",
         "lodash.isempty": "^4.4.0",
@@ -12381,6 +12411,7 @@
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/simpl-schema/-/simpl-schema-1.5.7.tgz",
       "integrity": "sha512-YxezVU4odQK6kY6NcmdypkS0MntahpfVpbK0zZCyI+12V43imynM/z024W+iHJpaL2aFDqZYgOVbeg8HjZU3ZQ==",
+      "dev": true,
       "requires": {
         "clone": "^2.1.2",
         "extend": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@reactioncommerce/plugin-payments-example",
+  "name": "@reactioncommerce/api-plugin-payments-example",
   "description": "Example Payments plugin for the Reaction API",
   "version": "0.0.0-development",
   "main": "index.js",
@@ -7,12 +7,12 @@
   "engines": {
     "node": ">=12.14.1"
   },
-  "homepage": "https://github.com/reactioncommerce/plugin-payments-example",
-  "url": "https://github.com/reactioncommerce/plugin-payments-example",
+  "homepage": "https://github.com/reactioncommerce/api-plugin-payments-example",
+  "url": "https://github.com/reactioncommerce/api-plugin-payments-example",
   "email": "engineering@reactioncommerce.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/reactioncommerce/plugin-payments-example.git"
+    "url": "git+https://github.com/reactioncommerce/api-plugin-payments-example.git"
   },
   "author": {
     "name": "Reaction Commerce",
@@ -21,7 +21,7 @@
   },
   "license": "GPL-3.0",
   "bugs": {
-    "url": "https://github.com/reactioncommerce/plugin-payments-example/issues"
+    "url": "https://github.com/reactioncommerce/api-plugin-payments-example/issues"
   },
   "sideEffects": false,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,8 @@ import startup from "./startup.js";
  */
 export default async function register(app) {
   await app.registerPlugin({
-    label: "ExamplePayment",
-    name: "example-paymentmethod",
+    label: "Example Payments",
+    name: "payments-example",
     version: pkg.version,
     i18n,
     graphQL: {


### PR DESCRIPTION
Resolves #3 

Rename this plugin from `plugin-payments-example` to `api-plugin-payments-example`.

This will create a new npm package with a v1.2.0, and this new package will need to be installed in reaction core.

We also need to deprecate the existing npm package.